### PR TITLE
Implement team management and player assignment workflows

### DIFF
--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -20,6 +20,19 @@ export interface Player {
   z_fg3m: number
   z_tov: number
   positions?: string[] // Changed from position to positions array
+  team_id?: number | null
+  team_name?: string | null
+}
+
+export interface Team {
+  id?: number
+  name: string
+  manager?: string | null
+  notes?: string | null
+}
+
+export interface TeamWithPlayers extends Team {
+  players: Player[]
 }
 
 export class DatabaseService {
@@ -45,7 +58,8 @@ export class DatabaseService {
           return
         }
         
-        this.createTable()
+        this.createPlayersTable()
+          .then(() => this.createTeamsTables())
           .then(() => this.migrateToMultiplePositions())
           .then(() => resolve())
           .catch(reject)
@@ -53,7 +67,7 @@ export class DatabaseService {
     })
   }
 
-  private createTable(): Promise<void> {
+  private createPlayersTable(): Promise<void> {
     return new Promise((resolve, reject) => {
       if (!this.db) {
         reject(new Error('Database not initialized'))
@@ -89,6 +103,55 @@ export class DatabaseService {
         } else {
           resolve()
         }
+      })
+    })
+  }
+
+  private createTeamsTables(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'))
+        return
+      }
+
+      const createTeamsSQL = `
+        CREATE TABLE IF NOT EXISTS teams (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT NOT NULL UNIQUE,
+          manager TEXT,
+          notes TEXT,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+      `
+
+      const createTeamPlayersSQL = `
+        CREATE TABLE IF NOT EXISTS team_players (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          team_id INTEGER NOT NULL,
+          player_id INTEGER NOT NULL UNIQUE,
+          assigned_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          FOREIGN KEY(team_id) REFERENCES teams(id) ON DELETE CASCADE,
+          FOREIGN KEY(player_id) REFERENCES players(id) ON DELETE CASCADE
+        )
+      `
+
+      this.db.serialize(() => {
+        this.db!.run('PRAGMA foreign_keys = ON')
+        this.db!.run(createTeamsSQL, (err) => {
+          if (err) {
+            reject(err)
+            return
+          }
+
+          this.db!.run(createTeamPlayersSQL, (err2) => {
+            if (err2) {
+              reject(err2)
+            } else {
+              resolve()
+            }
+          })
+        })
       })
     })
   }
@@ -158,7 +221,9 @@ export class DatabaseService {
         return
       }
 
-      this.db.run('DELETE FROM players', (err) => {
+      this.db.serialize(() => {
+        this.db!.run('DELETE FROM team_players')
+        this.db!.run('DELETE FROM players', (err) => {
         if (err) {
           reject(err)
           return
@@ -205,6 +270,7 @@ export class DatabaseService {
           })
         })
       })
+      })
     })
   }
 
@@ -216,8 +282,11 @@ export class DatabaseService {
       }
 
       const sql = `
-        SELECT * FROM players 
-        ORDER BY total_score DESC
+        SELECT p.*, tp.team_id as team_id, t.name as team_name
+        FROM players p
+        LEFT JOIN team_players tp ON p.id = tp.player_id
+        LEFT JOIN teams t ON tp.team_id = t.id
+        ORDER BY p.total_score DESC
       `
 
       this.db.all(sql, [], (err, rows: any[]) => {
@@ -264,12 +333,16 @@ export class DatabaseService {
         : '0'
 
       let sql = `
-        SELECT ${selectColumns.join(', ')},
-               (${totalScoreCalc}) as total_score
-        FROM players
+        SELECT ${selectColumns.map(col => `p.${col}`).join(', ')},
+               (${totalScoreCalc}) as total_score,
+               tp.team_id as team_id,
+               t.name as team_name
+        FROM players p
+        LEFT JOIN team_players tp ON p.id = tp.player_id
+        LEFT JOIN teams t ON tp.team_id = t.id
         WHERE 1=1
       `
-      
+
       const params: any[] = []
 
       if (filters.minGames) {
@@ -387,8 +460,14 @@ export class DatabaseService {
         return
       }
 
-      const sql = 'SELECT * FROM players WHERE PLAYER_NAME = ?'
-      
+      const sql = `
+        SELECT p.*, tp.team_id as team_id, t.name as team_name
+        FROM players p
+        LEFT JOIN team_players tp ON p.id = tp.player_id
+        LEFT JOIN teams t ON tp.team_id = t.id
+        WHERE p.PLAYER_NAME = ?
+      `
+
       this.db.get(sql, [name], (err, row: any) => {
         if (err) {
           reject(err)
@@ -399,6 +478,214 @@ export class DatabaseService {
           } as Player)
         } else {
           resolve(null)
+        }
+      })
+    })
+  }
+
+  async getTeams(): Promise<TeamWithPlayers[]> {
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'))
+        return
+      }
+
+      const sql = `
+        SELECT
+          t.id as team_id,
+          t.name,
+          t.manager,
+          t.notes,
+          p.id as player_id,
+          p.PLAYER_NAME,
+          p.GP,
+          p.availability_rate,
+          p.FT_PCT,
+          p.total_score,
+          p.z_pts,
+          p.z_ast,
+          p.z_reb,
+          p.z_stl,
+          p.z_blk,
+          p.z_fg_pct,
+          p.z_ft_pct,
+          p.z_fg3m,
+          p.z_tov,
+          p.positions
+        FROM teams t
+        LEFT JOIN team_players tp ON t.id = tp.team_id
+        LEFT JOIN players p ON tp.player_id = p.id
+        ORDER BY t.name ASC, p.total_score DESC
+      `
+
+      this.db.all(sql, [], (err, rows: any[]) => {
+        if (err) {
+          reject(err)
+          return
+        }
+
+        const teamMap = new Map<number, TeamWithPlayers>()
+
+        rows.forEach(row => {
+          const teamId = row.team_id as number
+          if (!teamMap.has(teamId)) {
+            teamMap.set(teamId, {
+              id: teamId,
+              name: row.name,
+              manager: row.manager,
+              notes: row.notes,
+              players: []
+            })
+          }
+
+          if (row.player_id) {
+            const team = teamMap.get(teamId)
+            if (team) {
+              team.players.push({
+                id: row.player_id,
+                PLAYER_NAME: row.PLAYER_NAME,
+                GP: row.GP,
+                availability_rate: row.availability_rate,
+                FT_PCT: row.FT_PCT,
+                total_score: row.total_score,
+                z_pts: row.z_pts,
+                z_ast: row.z_ast,
+                z_reb: row.z_reb,
+                z_stl: row.z_stl,
+                z_blk: row.z_blk,
+                z_fg_pct: row.z_fg_pct,
+                z_ft_pct: row.z_ft_pct,
+                z_fg3m: row.z_fg3m,
+                z_tov: row.z_tov,
+                positions: this.parsePositions(row.positions),
+                team_id: teamId,
+                team_name: row.name
+              })
+            }
+          }
+        })
+
+        const teams: TeamWithPlayers[] = rows.length === 0
+          ? []
+          : Array.from(teamMap.values())
+
+        resolve(teams)
+      })
+    })
+  }
+
+  async createTeam(team: Team): Promise<Team> {
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'))
+        return
+      }
+
+      const sql = `
+        INSERT INTO teams (name, manager, notes)
+        VALUES (?, ?, ?)
+      `
+
+      this.db.run(sql, [team.name, team.manager || null, team.notes || null], function (err) {
+        if (err) {
+          reject(err)
+        } else {
+          resolve({ ...team, id: this.lastID })
+        }
+      })
+    })
+  }
+
+  async updateTeam(id: number, updates: Partial<Team>): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'))
+        return
+      }
+
+      const fields = Object.keys(updates)
+      if (fields.length === 0) {
+        resolve()
+        return
+      }
+
+      const sql = `
+        UPDATE teams
+        SET ${fields.map(field => `${field} = ?`).join(', ')},
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?
+      `
+
+      const params = [...fields.map(field => (updates as any)[field]), id]
+
+      this.db.run(sql, params, (err) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
+  async deleteTeam(id: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'))
+        return
+      }
+
+      const sql = 'DELETE FROM teams WHERE id = ?'
+
+      this.db.run(sql, [id], (err) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
+  async assignPlayerToTeam(teamId: number, playerId: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'))
+        return
+      }
+
+      const sql = `
+        INSERT INTO team_players (team_id, player_id)
+        VALUES (?, ?)
+        ON CONFLICT(player_id) DO UPDATE SET
+          team_id = excluded.team_id,
+          assigned_at = CURRENT_TIMESTAMP
+      `
+
+      this.db.run(sql, [teamId, playerId], (err) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
+  async removePlayerFromTeam(playerId: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'))
+        return
+      }
+
+      const sql = 'DELETE FROM team_players WHERE player_id = ?'
+
+      this.db.run(sql, [playerId], (err) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
         }
       })
     })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,12 @@ import fs from 'fs'
 
 let dbService: DatabaseService | null = null
 
+function getDatabase(): DatabaseService {
+  if (!dbService) {
+    throw new Error('Database service is not initialized')
+  }
+  return dbService
+}
 
 function createWindow(): void {
   // Create the browser window.
@@ -20,13 +26,13 @@ function createWindow(): void {
     backgroundColor: '#0f172a', // Dark background color
     titleBarStyle: process.platform === 'darwin' ? 'default' : 'default',
     vibrancy: process.platform === 'darwin' ? 'appearance-based' : undefined,
-    webSecurity: false,
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: false,
       nodeIntegration: false,
-      contextIsolation: true
+      contextIsolation: true,
+      webSecurity: false
     }
   })
 
@@ -118,7 +124,7 @@ ipcMain.handle('db:importCsv', async (_, filePath: string) => {
               total_score: zColumns.reduce((sum, col) => sum + (player[col] || 0), 0)
             }))
             
-            await dbService.importFromCSV(dataWithScores)
+            await getDatabase().importFromCSV(dataWithScores)
             resolve({ success: true, count: dataWithScores.length })
           } catch (error) {
             reject(error)
@@ -136,7 +142,7 @@ ipcMain.handle('db:importCsv', async (_, filePath: string) => {
 
 ipcMain.handle('db:getAllPlayers', async () => {
   try {
-    return await dbService.getAllPlayers()
+    return await getDatabase().getAllPlayers()
   } catch (error) {
     throw new Error(`Failed to get players: ${error instanceof Error ? error.message : 'Unknown error'}`)
   }
@@ -144,7 +150,7 @@ ipcMain.handle('db:getAllPlayers', async () => {
 
 ipcMain.handle('db:getPlayersWithFilters', async (_, filters) => {
   try {
-    return await dbService.getPlayersWithFilters(filters)
+    return await getDatabase().getPlayersWithFilters(filters)
   } catch (error) {
     throw new Error(`Failed to get filtered players: ${error instanceof Error ? error.message : 'Unknown error'}`)
   }
@@ -152,7 +158,7 @@ ipcMain.handle('db:getPlayersWithFilters', async (_, filters) => {
 
 ipcMain.handle('db:getPlayerByName', async (_, name: string) => {
   try {
-    return await dbService.getPlayerByName(name)
+    return await getDatabase().getPlayerByName(name)
   } catch (error) {
     throw new Error(`Failed to get player: ${error instanceof Error ? error.message : 'Unknown error'}`)
   }
@@ -160,7 +166,7 @@ ipcMain.handle('db:getPlayerByName', async (_, name: string) => {
 
 ipcMain.handle('db:getStatistics', async () => {
   try {
-    return await dbService.getStatistics()
+    return await getDatabase().getStatistics()
   } catch (error) {
     throw new Error(`Failed to get statistics: ${error instanceof Error ? error.message : 'Unknown error'}`)
   }
@@ -168,7 +174,7 @@ ipcMain.handle('db:getStatistics', async () => {
 
 ipcMain.handle('db:updatePlayer', async (_, id: number, updates) => {
   try {
-    await dbService.updatePlayer(id, updates)
+    await getDatabase().updatePlayer(id, updates)
     return { success: true }
   } catch (error) {
     throw new Error(`Failed to update player: ${error instanceof Error ? error.message : 'Unknown error'}`)
@@ -177,7 +183,7 @@ ipcMain.handle('db:updatePlayer', async (_, id: number, updates) => {
 
 ipcMain.handle('db:deletePlayer', async (_, id: number) => {
   try {
-    await dbService.deletePlayer(id)
+    await getDatabase().deletePlayer(id)
     return { success: true }
   } catch (error) {
     throw new Error(`Failed to delete player: ${error instanceof Error ? error.message : 'Unknown error'}`)
@@ -185,7 +191,59 @@ ipcMain.handle('db:deletePlayer', async (_, id: number) => {
 })
 
 ipcMain.handle('db:getZColumns', () => {
-  return dbService.getZColumns()
+  return getDatabase().getZColumns()
+})
+
+ipcMain.handle('db:getTeams', async () => {
+  try {
+    return await getDatabase().getTeams()
+  } catch (error) {
+    throw new Error(`Failed to get teams: ${error instanceof Error ? error.message : 'Unknown error'}`)
+  }
+})
+
+ipcMain.handle('db:createTeam', async (_, team) => {
+  try {
+    return await getDatabase().createTeam(team)
+  } catch (error) {
+    throw new Error(`Failed to create team: ${error instanceof Error ? error.message : 'Unknown error'}`)
+  }
+})
+
+ipcMain.handle('db:updateTeam', async (_, id: number, updates) => {
+  try {
+    await getDatabase().updateTeam(id, updates)
+    return { success: true }
+  } catch (error) {
+    throw new Error(`Failed to update team: ${error instanceof Error ? error.message : 'Unknown error'}`)
+  }
+})
+
+ipcMain.handle('db:deleteTeam', async (_, id: number) => {
+  try {
+    await getDatabase().deleteTeam(id)
+    return { success: true }
+  } catch (error) {
+    throw new Error(`Failed to delete team: ${error instanceof Error ? error.message : 'Unknown error'}`)
+  }
+})
+
+ipcMain.handle('db:assignPlayerToTeam', async (_, teamId: number, playerId: number) => {
+  try {
+    await getDatabase().assignPlayerToTeam(teamId, playerId)
+    return { success: true }
+  } catch (error) {
+    throw new Error(`Failed to assign player: ${error instanceof Error ? error.message : 'Unknown error'}`)
+  }
+})
+
+ipcMain.handle('db:removePlayerFromTeam', async (_, playerId: number) => {
+  try {
+    await getDatabase().removePlayerFromTeam(playerId)
+    return { success: true }
+  } catch (error) {
+    throw new Error(`Failed to remove player: ${error instanceof Error ? error.message : 'Unknown error'}`)
+  }
 })
 
 // This method will be called when Electron has finished
@@ -242,7 +300,7 @@ app.on('before-quit', async () => {
 
 ipcMain.handle('db:updatePlayerPositions', async (_, id: number, positions: string[]) => {
   try {
-    await dbService.updatePlayerPositions(id, positions)
+    await getDatabase().updatePlayerPositions(id, positions)
     return { success: true }
   } catch (error) {
     throw new Error(`Failed to update player positions: ${error instanceof Error ? error.message : 'Unknown error'}`)
@@ -251,7 +309,7 @@ ipcMain.handle('db:updatePlayerPositions', async (_, id: number, positions: stri
 
 ipcMain.handle('db:bulkUpdatePositions', async (_, updates: { id: number, positions: string[] }[]) => {
   try {
-    await dbService.bulkUpdatePositions(updates)
+    await getDatabase().bulkUpdatePositions(updates)
     return { success: true, count: updates.length }
   } catch (error) {
     throw new Error(`Failed to bulk update positions: ${error instanceof Error ? error.message : 'Unknown error'}`)
@@ -259,5 +317,5 @@ ipcMain.handle('db:bulkUpdatePositions', async (_, updates: { id: number, positi
 })
 
 ipcMain.handle('db:getPositions', () => {
-  return dbService.getPositions()
+  return getDatabase().getPositions()
 })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -15,6 +15,15 @@ declare global {
         updatePlayer: (id: number, updates: any) => Promise<{ success: boolean }>
         deletePlayer: (id: number) => Promise<{ success: boolean }>
         getZColumns: () => Promise<string[]>
+        getTeams: () => Promise<any[]>
+        createTeam: (team: any) => Promise<any>
+        updateTeam: (id: number, updates: any) => Promise<{ success: boolean }>
+        deleteTeam: (id: number) => Promise<{ success: boolean }>
+        assignPlayerToTeam: (teamId: number, playerId: number) => Promise<{ success: boolean }>
+        removePlayerFromTeam: (playerId: number) => Promise<{ success: boolean }>
+        updatePlayerPositions: (id: number, positions: string[]) => Promise<{ success: boolean }>
+        bulkUpdatePositions: (updates: { id: number, positions: string[] }[]) => Promise<{ success: boolean; count: number }>
+        getPositions: () => Promise<string[]>
       }
     }
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,6 +14,12 @@ const api = {
     updatePlayer: (id: number, updates: any) => ipcRenderer.invoke('db:updatePlayer', id, updates),
     deletePlayer: (id: number) => ipcRenderer.invoke('db:deletePlayer', id),
     getZColumns: () => ipcRenderer.invoke('db:getZColumns'),
+    getTeams: () => ipcRenderer.invoke('db:getTeams'),
+    createTeam: (team: any) => ipcRenderer.invoke('db:createTeam', team),
+    updateTeam: (id: number, updates: any) => ipcRenderer.invoke('db:updateTeam', id, updates),
+    deleteTeam: (id: number) => ipcRenderer.invoke('db:deleteTeam', id),
+    assignPlayerToTeam: (teamId: number, playerId: number) => ipcRenderer.invoke('db:assignPlayerToTeam', teamId, playerId),
+    removePlayerFromTeam: (playerId: number) => ipcRenderer.invoke('db:removePlayerFromTeam', playerId),
     // New position-related functions
     updatePlayerPositions: (id: number, positions: string[]) => ipcRenderer.invoke('db:updatePlayerPositions', id, positions),
     bulkUpdatePositions: (updates: { id: number, positions: string[] }[]) => ipcRenderer.invoke('db:bulkUpdatePositions', updates),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import { ControlPanel } from './components/ControlPanel'
 import { PlayerList } from './components/PlayerList'
 import { PlayerDetails } from './components/PlayerDetails'
 import { Visualizations } from './components/Visualizations'
+import { TeamsSection } from './components/TeamsSection'
 import { useNBAStore } from './store/nbaStore'
 import './globals.css'
 
@@ -29,12 +30,13 @@ function App() {
       {/* Right Panel - Data Display */}
       <div className="flex-1 flex flex-col">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 flex flex-col">
-          <TabsList className="grid w-full grid-cols-3 m-4 mb-0">
+          <TabsList className="grid w-full grid-cols-4 m-4 mb-0">
             <TabsTrigger value="players">Player List ({filteredPlayers.length})</TabsTrigger>
             <TabsTrigger value="details" disabled={!selectedPlayer}>
               Player Details
             </TabsTrigger>
             <TabsTrigger value="visualizations">Visualizations</TabsTrigger>
+            <TabsTrigger value="teams">Teams</TabsTrigger>
           </TabsList>
 
           <div className="flex-1 p-4 pt-2 overflow-hidden">
@@ -48,6 +50,10 @@ function App() {
 
             <TabsContent value="visualizations" className="h-full">
               <Visualizations />
+            </TabsContent>
+
+            <TabsContent value="teams" className="h-full">
+              <TeamsSection />
             </TabsContent>
           </div>
         </Tabs>

--- a/src/renderer/src/components/ControlPanel.tsx
+++ b/src/renderer/src/components/ControlPanel.tsx
@@ -1,15 +1,14 @@
-import { useRef, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
 import { Label } from './ui/label'
 import { Checkbox } from './ui/checkbox'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
-import { Separator } from './ui/separator'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from './ui/dialog'
 import { ScrollArea } from './ui/scroll-area'
 import { useNBAStore } from '../store/nbaStore'
-import { RotateCcw, Download, BarChart3, Info, Database, Plus, Minus } from 'lucide-react'
+import { RotateCcw, Download, Info, Database, Plus, Minus } from 'lucide-react'
 import { PositionEditor } from './PositionEditor'
 
 // Custom Number Input Component
@@ -84,7 +83,6 @@ export function ControlPanel() {
   const {
     filters,
     availableCategories,
-    isLoading,
     error,
     applyFilters,
     exportFilteredData,

--- a/src/renderer/src/components/PlayerDetails.tsx
+++ b/src/renderer/src/components/PlayerDetails.tsx
@@ -3,6 +3,7 @@ import { Badge } from './ui/badge'
 import { Separator } from './ui/separator'
 import { ScrollArea } from './ui/scroll-area'
 import { Progress } from './ui/progress'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select'
 import { 
   ResponsiveContainer, 
   RadarChart, 
@@ -19,7 +20,12 @@ import {
 import { useNBAStore } from '../store/nbaStore'
 
 export function PlayerDetails() {
-  const { selectedPlayer, getPlayerRank, filteredPlayers } = useNBAStore()
+  const selectedPlayer = useNBAStore(state => state.selectedPlayer)
+  const getPlayerRank = useNBAStore(state => state.getPlayerRank)
+  const filteredPlayers = useNBAStore(state => state.filteredPlayers)
+  const teams = useNBAStore(state => state.teams)
+  const assignPlayerToTeam = useNBAStore(state => state.assignPlayerToTeam)
+  const removePlayerFromTeam = useNBAStore(state => state.removePlayerFromTeam)
 
   if (!selectedPlayer) {
     return (
@@ -58,6 +64,23 @@ export function PlayerDetails() {
   }
 
   const availabilityInfo = getAvailabilityInfo(selectedPlayer.availability_rate)
+  const currentTeamSelection = selectedPlayer.team_id ? String(selectedPlayer.team_id) : 'unassigned'
+
+  const handleTeamAssignmentChange = async (value: string) => {
+    if (!selectedPlayer?.id) {
+      return
+    }
+
+    if (value === 'unassigned') {
+      await removePlayerFromTeam(selectedPlayer.id)
+      return
+    }
+
+    const teamId = Number(value)
+    if (!Number.isNaN(teamId) && teamId !== selectedPlayer.team_id) {
+      await assignPlayerToTeam(teamId, selectedPlayer.id)
+    }
+  }
 
   // Get color based on availability percentage (red to green gradient)
   const getAvailabilityColor = (rate: number) => {
@@ -156,26 +179,56 @@ export function PlayerDetails() {
                 <p className="text-sm font-medium text-muted-foreground">Total Score</p>
                 <p className="text-2xl font-bold">{selectedPlayer.total_score.toFixed(2)}</p>
               </div>
-              <div className="space-y-2">
-                <p className="text-sm font-medium text-muted-foreground">Position{selectedPlayer.positions && selectedPlayer.positions.length > 1 ? 's' : ''}</p>
-                <div>
-                  {selectedPlayer.positions && selectedPlayer.positions.length > 0 ? (
-                    <div className="flex flex-wrap gap-1">
-                      {selectedPlayer.positions.map(pos => (
-                        <Badge 
-                          key={pos}
-                          variant={
-                            ['PG', 'SG'].includes(pos) ? 'default' : 'secondary'
-                          } 
-                          className="text-lg px-3 py-1"
-                        >
-                          {pos}
-                        </Badge>
-                      ))}
-                    </div>
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <p className="text-sm font-medium text-muted-foreground">Position{selectedPlayer.positions && selectedPlayer.positions.length > 1 ? 's' : ''}</p>
+                  <div>
+                    {selectedPlayer.positions && selectedPlayer.positions.length > 0 ? (
+                      <div className="flex flex-wrap gap-1">
+                        {selectedPlayer.positions.map(pos => (
+                          <Badge
+                            key={pos}
+                            variant={
+                              ['PG', 'SG'].includes(pos) ? 'default' : 'secondary'
+                            }
+                            className="text-lg px-3 py-1"
+                          >
+                            {pos}
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-lg text-muted-foreground">Not assigned</span>
+                    )}
+                  </div>
+                </div>
+                <Separator />
+                <div className="space-y-2">
+                  <p className="text-sm font-medium text-muted-foreground">Team Assignment</p>
+                  {selectedPlayer.team_name ? (
+                    <Badge variant="outline" className="text-lg px-3 py-1">
+                      {selectedPlayer.team_name}
+                    </Badge>
                   ) : (
-                    <span className="text-lg text-muted-foreground">Not assigned</span>
+                    <span className="text-sm text-muted-foreground">Unassigned</span>
                   )}
+                  <Select
+                    value={currentTeamSelection}
+                    onValueChange={handleTeamAssignmentChange}
+                    disabled={!teams.length && !selectedPlayer.team_id}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder={teams.length ? 'Assign to team' : 'Create a team first'} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="unassigned">Unassigned</SelectItem>
+                      {teams.map(team => (
+                        <SelectItem key={team.id} value={String(team.id)}>
+                          {team.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
               <div className="space-y-2">
@@ -209,7 +262,7 @@ export function PlayerDetails() {
                         <PolarRadiusAxis tick={false} tickLine={false} axisLine={false}>
                           <Label
                             content={({ viewBox }) => {
-                              if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                              if (viewBox && 'cx' in viewBox && 'cy' in viewBox) {
                                 return (
                                   <text
                                     x={viewBox.cx}
@@ -227,6 +280,7 @@ export function PlayerDetails() {
                                   </text>
                                 )
                               }
+                              return null
                             }}
                           />
                         </PolarRadiusAxis>

--- a/src/renderer/src/components/PlayerList.tsx
+++ b/src/renderer/src/components/PlayerList.tsx
@@ -113,6 +113,7 @@ export function PlayerList({ onPlayerSelect }: PlayerListProps) {
               <TableRow>
                 <TableHead className="w-16">Rank</TableHead>
                 <TableHead>Player Name</TableHead>
+                <TableHead>Team</TableHead>
                 <TableHead>Position</TableHead>
                 <TableHead className="text-right">Score</TableHead>
                 <TableHead className="text-right">Games</TableHead>
@@ -133,6 +134,9 @@ export function PlayerList({ onPlayerSelect }: PlayerListProps) {
                   </TableCell>
                   <TableCell className="font-medium">
                     {player.PLAYER_NAME}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                    {player.team_name || 'Unassigned'}
                   </TableCell>
                   <TableCell>
                     {player.positions && player.positions.length > 0 ? (

--- a/src/renderer/src/components/TeamsSection.tsx
+++ b/src/renderer/src/components/TeamsSection.tsx
@@ -1,0 +1,403 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Users, UserPlus, Trophy, Edit, Trash2 } from 'lucide-react'
+import { useNBAStore, Team } from '../store/nbaStore'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
+import { Button } from './ui/button'
+import { Input } from './ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select'
+import { Badge } from './ui/badge'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table'
+import { ScrollArea } from './ui/scroll-area'
+import { Separator } from './ui/separator'
+
+export function TeamsSection() {
+  const teams = useNBAStore(state => state.teams)
+  const teamsLoading = useNBAStore(state => state.teamsLoading)
+  const allPlayers = useNBAStore(state => state.allPlayers)
+  const loadTeams = useNBAStore(state => state.loadTeams)
+  const createTeam = useNBAStore(state => state.createTeam)
+  const updateTeam = useNBAStore(state => state.updateTeam)
+  const deleteTeam = useNBAStore(state => state.deleteTeam)
+  const assignPlayerToTeam = useNBAStore(state => state.assignPlayerToTeam)
+  const removePlayerFromTeam = useNBAStore(state => state.removePlayerFromTeam)
+
+  const [newTeamName, setNewTeamName] = useState('')
+  const [newTeamManager, setNewTeamManager] = useState('')
+  const [editingTeamId, setEditingTeamId] = useState<number | null>(null)
+  const [editValues, setEditValues] = useState<{ name: string; manager: string }>({ name: '', manager: '' })
+  const [teamSelections, setTeamSelections] = useState<Record<number, string>>({})
+  const [playerSelections, setPlayerSelections] = useState<Record<number, string>>({})
+
+  useEffect(() => {
+    if (!teamsLoading && teams.length === 0) {
+      loadTeams()
+    }
+  }, [teams.length, teamsLoading, loadTeams])
+
+  const assignedCount = useMemo(() => allPlayers.filter(player => !!player.team_id).length, [allPlayers])
+  const unassignedPlayers = useMemo(
+    () =>
+      allPlayers
+        .filter(player => !player.team_id && player.id)
+        .sort((a, b) => a.PLAYER_NAME.localeCompare(b.PLAYER_NAME)),
+    [allPlayers]
+  )
+
+  const handleCreateTeam = async (event: React.FormEvent) => {
+    event.preventDefault()
+    const name = newTeamName.trim()
+    const manager = newTeamManager.trim()
+
+    if (!name) {
+      return
+    }
+
+    await createTeam({ name, manager: manager || null })
+    setNewTeamName('')
+    setNewTeamManager('')
+  }
+
+  const startEditing = (team: Team) => {
+    setEditingTeamId(team.id)
+    setEditValues({ name: team.name, manager: team.manager || '' })
+  }
+
+  const cancelEditing = () => {
+    setEditingTeamId(null)
+    setEditValues({ name: '', manager: '' })
+  }
+
+  const handleUpdateTeam = async (team: Team) => {
+    const name = editValues.name.trim()
+    const manager = editValues.manager.trim()
+
+    const updates: Partial<Team> = {}
+    if (name && name !== team.name) {
+      updates.name = name
+    }
+    if (manager !== (team.manager || '')) {
+      updates.manager = manager || null
+    }
+
+    if (Object.keys(updates).length > 0) {
+      await updateTeam(team.id, updates)
+    }
+    cancelEditing()
+  }
+
+  const handleDeleteTeam = async (team: Team) => {
+    const confirmed = window.confirm(`Delete team "${team.name}"? Players will become unassigned.`)
+    if (confirmed) {
+      await deleteTeam(team.id)
+    }
+  }
+
+  const handleAssignSelection = async (selection: string) => {
+    const [teamIdValue, playerIdValue] = selection.split(':')
+    const teamId = Number(teamIdValue)
+    const playerId = Number(playerIdValue)
+
+    if (!Number.isNaN(teamId) && !Number.isNaN(playerId)) {
+      await assignPlayerToTeam(teamId, playerId)
+    }
+  }
+
+  const handleRemovePlayer = async (playerId: number) => {
+    await removePlayerFromTeam(playerId)
+  }
+
+  return (
+    <div className="h-full flex flex-col gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-base font-semibold">
+              <Users className="h-4 w-4" />
+              Teams
+            </CardTitle>
+            <CardDescription>Total active teams in the league</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold">{teams.length}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-base font-semibold">
+              <Trophy className="h-4 w-4" />
+              Players Assigned
+            </CardTitle>
+            <CardDescription>Prospects that are currently on a roster</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold">{assignedCount}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-base font-semibold">
+              <UserPlus className="h-4 w-4" />
+              Available Players
+            </CardTitle>
+            <CardDescription>Prospects not yet assigned to a team</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold">{unassignedPlayers.length}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Create a Team</CardTitle>
+            <CardDescription>Set up a manager and start drafting players to their roster.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleCreateTeam} className="space-y-3">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Team Name</label>
+                <Input
+                  placeholder="e.g. Downtown Shooters"
+                  value={newTeamName}
+                  onChange={(event) => setNewTeamName(event.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Manager</label>
+                <Input
+                  placeholder="Owner or manager name (optional)"
+                  value={newTeamManager}
+                  onChange={(event) => setNewTeamManager(event.target.value)}
+                />
+              </div>
+              <Button type="submit" className="w-full" disabled={!newTeamName.trim()}>
+                Create Team
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Unassigned Players</CardTitle>
+            <CardDescription>Select a team to draft a player directly from here.</CardDescription>
+          </CardHeader>
+          <CardContent className="p-0">
+            <ScrollArea className="h-48">
+              <div className="p-4 space-y-2">
+                {unassignedPlayers.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">All players have been assigned to teams.</p>
+                ) : (
+                  unassignedPlayers.map(player => (
+                    <div key={player.id ?? player.PLAYER_NAME} className="flex items-center justify-between">
+                      <div>
+                        <p className="text-sm font-medium">{player.PLAYER_NAME}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {player.positions && player.positions.length > 0 ? player.positions.join(' / ') : 'No position'}
+                        </p>
+                      </div>
+                      <Select
+                        value={player.id ? playerSelections[player.id] : undefined}
+                        onValueChange={async (value) => {
+                          if (!player.id) return
+                          setPlayerSelections(prev => ({ ...prev, [player.id as number]: value }))
+                          await handleAssignSelection(value)
+                          setPlayerSelections(prev => {
+                            const updated = { ...prev }
+                            delete updated[player.id as number]
+                            return updated
+                          })
+                        }}
+                      >
+                        <SelectTrigger className="w-40">
+                          <SelectValue placeholder="Assign to team" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {teams.map(team => (
+                            <SelectItem
+                              key={team.id}
+                              value={`${team.id}:${player.id}`}
+                              disabled={!player.id}
+                            >
+                              {team.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  ))
+                )}
+              </div>
+            </ScrollArea>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Separator />
+
+      <div className="flex-1 overflow-hidden">
+        <ScrollArea className="h-full pr-2">
+          <div className="space-y-4">
+            {teamsLoading && teams.length === 0 ? (
+              <Card>
+                <CardContent className="py-10 text-center text-muted-foreground">
+                  Loading teams...
+                </CardContent>
+              </Card>
+            ) : teams.length === 0 ? (
+              <Card>
+                <CardContent className="py-10 text-center text-muted-foreground">
+                  No teams yet. Create one to start the draft!
+                </CardContent>
+              </Card>
+            ) : (
+              teams.map(team => {
+                const assignablePlayers = allPlayers
+                  .filter(player => (!!player.id && (!player.team_id || player.team_id === team.id)))
+                  .sort((a, b) => a.PLAYER_NAME.localeCompare(b.PLAYER_NAME))
+
+                const selectionValue = teamSelections[team.id]
+
+                return (
+                  <Card key={team.id}>
+                    <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="space-y-1">
+                        {editingTeamId === team.id ? (
+                          <div className="space-y-2">
+                            <Input
+                              value={editValues.name}
+                              onChange={(event) => setEditValues(prev => ({ ...prev, name: event.target.value }))}
+                              placeholder="Team name"
+                            />
+                            <Input
+                              value={editValues.manager}
+                              onChange={(event) => setEditValues(prev => ({ ...prev, manager: event.target.value }))}
+                              placeholder="Manager"
+                            />
+                          </div>
+                        ) : (
+                          <>
+                            <CardTitle className="text-xl">{team.name}</CardTitle>
+                            <CardDescription>
+                              {team.manager ? `Managed by ${team.manager}` : 'Manager not set'}
+                            </CardDescription>
+                          </>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {editingTeamId === team.id ? (
+                          <>
+                            <Button variant="secondary" size="sm" onClick={() => handleUpdateTeam(team)}>
+                              Save
+                            </Button>
+                            <Button variant="ghost" size="sm" onClick={cancelEditing}>
+                              Cancel
+                            </Button>
+                          </>
+                        ) : (
+                          <>
+                            <Button variant="outline" size="icon" onClick={() => startEditing(team)}>
+                              <Edit className="h-4 w-4" />
+                            </Button>
+                            <Button variant="destructive" size="icon" onClick={() => handleDeleteTeam(team)}>
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </>
+                        )}
+                      </div>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <p className="text-sm text-muted-foreground">
+                            {team.players.length} player{team.players.length === 1 ? '' : 's'} on this roster
+                          </p>
+                        </div>
+                        <Select
+                          value={selectionValue}
+                          onValueChange={async (value) => {
+                            setTeamSelections(prev => ({ ...prev, [team.id]: value }))
+                            await handleAssignSelection(value)
+                            setTeamSelections(prev => {
+                              const updated = { ...prev }
+                              delete updated[team.id]
+                              return updated
+                            })
+                          }}
+                        >
+                          <SelectTrigger className="w-56">
+                            <SelectValue placeholder="Draft player to team" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {assignablePlayers.map(player => (
+                              <SelectItem key={player.id ?? player.PLAYER_NAME} value={`${team.id}:${player.id}`}>
+                                {player.PLAYER_NAME}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      {team.players.length === 0 ? (
+                        <p className="text-sm text-muted-foreground">No players drafted yet.</p>
+                      ) : (
+                        <div className="border border-border rounded-lg overflow-hidden">
+                          <Table>
+                            <TableHeader>
+                              <TableRow>
+                                <TableHead>Player</TableHead>
+                                <TableHead>Positions</TableHead>
+                                <TableHead className="text-right">Score</TableHead>
+                                <TableHead className="text-right">Games</TableHead>
+                                <TableHead className="w-20"></TableHead>
+                              </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                              {team.players.map(player => (
+                                <TableRow key={player.id ?? player.PLAYER_NAME}>
+                                  <TableCell className="font-medium">{player.PLAYER_NAME}</TableCell>
+                                  <TableCell>
+                                    {player.positions && player.positions.length > 0 ? (
+                                      <div className="flex flex-wrap gap-1">
+                                        {player.positions.map(position => (
+                                          <Badge key={position} variant={['PG', 'SG'].includes(position) ? 'default' : 'secondary'}>
+                                            {position}
+                                          </Badge>
+                                        ))}
+                                      </div>
+                                    ) : (
+                                      <span className="text-xs text-muted-foreground">No position</span>
+                                    )}
+                                  </TableCell>
+                                  <TableCell className="text-right font-mono text-sm">
+                                    {player.total_score.toFixed(2)}
+                                  </TableCell>
+                                  <TableCell className="text-right text-sm">{player.GP}</TableCell>
+                                  <TableCell className="text-right">
+                                    <Button
+                                      variant="ghost"
+                                      size="icon"
+                                      onClick={() => player.id && handleRemovePlayer(player.id)}
+                                      title="Remove from team"
+                                    >
+                                      <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                  </TableCell>
+                                </TableRow>
+                              ))}
+                            </TableBody>
+                          </Table>
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                )
+              })
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/Visualizations.tsx
+++ b/src/renderer/src/components/Visualizations.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
 import { Button } from './ui/button'
-import { Badge } from './ui/badge'
 import { 
   ResponsiveContainer, 
   BarChart, 
@@ -15,7 +14,7 @@ import {
   Cell
 } from 'recharts'
 import { useNBAStore, type Player } from '../store/nbaStore'
-import { BarChart3, Zap, Grid3X3, Target, TrendingUp } from 'lucide-react'
+import { BarChart3, Grid3X3, Target, TrendingUp } from 'lucide-react'
 
 type VisualizationType = 'distribution' | 'bubble' | 'heatmap' | 'value' | null
 
@@ -205,7 +204,7 @@ export function Visualizations() {
             }}
           />
           <Bar dataKey="valueScore">
-            {data.map((entry, index) => {
+            {data.map((_entry, index) => {
               // Create gradient based on position in the filtered results
               const totalPlayers = data.length
               const percentile = (totalPlayers - index) / totalPlayers

--- a/src/renderer/src/store/nbaStore.ts
+++ b/src/renderer/src/store/nbaStore.ts
@@ -19,6 +19,16 @@ export interface Player {
   z_fg3m: number
   z_tov: number
   positions?: string[] // Changed to array
+  team_id?: number | null
+  team_name?: string | null
+}
+
+export interface Team {
+  id: number
+  name: string
+  manager?: string | null
+  notes?: string | null
+  players: Player[]
 }
 
 export interface Filters {
@@ -34,12 +44,15 @@ export interface Filters {
 interface NBAState {
   // Data
   filteredPlayers: Player[]
+  allPlayers: Player[]
   selectedPlayer: Player | null
-  
+  teams: Team[]
+
   // UI State
   isLoading: boolean
+  teamsLoading: boolean
   error: string | null
-  
+
   // Filters
   filters: Filters
   availableCategories: string[]
@@ -53,6 +66,12 @@ interface NBAState {
   loadInitialData: () => Promise<void>
   updatePlayer: (id: number, updates: Partial<Player>) => Promise<void>
   deletePlayer: (id: number) => Promise<void>
+  loadTeams: () => Promise<void>
+  createTeam: (team: { name: string; manager?: string | null; notes?: string | null }) => Promise<void>
+  updateTeam: (id: number, updates: Partial<Team>) => Promise<void>
+  deleteTeam: (id: number) => Promise<void>
+  assignPlayerToTeam: (teamId: number, playerId: number) => Promise<void>
+  removePlayerFromTeam: (playerId: number) => Promise<void>
 }
 
 const initialFilters: Filters = {
@@ -68,31 +87,40 @@ const initialFilters: Filters = {
 export const useNBAStore = create<NBAState>((set, get) => ({
   // Initial state
   filteredPlayers: [],
+  allPlayers: [],
   selectedPlayer: null,
+  teams: [],
   isLoading: false,
+  teamsLoading: false,
   error: null,
   filters: initialFilters,
   availableCategories: [],
 
   // Load initial data from database
   loadInitialData: async () => {
-    set({ isLoading: true, error: null })
-    
+    set({ isLoading: true, teamsLoading: true, error: null })
+
     try {
       // Get available z columns
       const zColumns = await window.api.db.getZColumns()
-      set({ availableCategories: zColumns })
-      
-      // Load all players
-      const players = await window.api.db.getAllPlayers()
-      set({ 
+      const [players, teams] = await Promise.all([
+        window.api.db.getAllPlayers(),
+        window.api.db.getTeams()
+      ])
+
+      set({
+        availableCategories: zColumns,
         filteredPlayers: players,
-        isLoading: false 
+        allPlayers: players,
+        teams,
+        isLoading: false,
+        teamsLoading: false
       })
     } catch (error) {
-      set({ 
+      set({
         error: `Failed to load data: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        isLoading: false 
+        isLoading: false,
+        teamsLoading: false
       })
     }
   },
@@ -155,17 +183,29 @@ export const useNBAStore = create<NBAState>((set, get) => ({
         dbFilters.limit = 200
       }
       
-      const players = await window.api.db.getPlayersWithFilters(dbFilters)
-      
-      set({ 
+      const [players, allPlayers] = await Promise.all([
+        window.api.db.getPlayersWithFilters(dbFilters),
+        window.api.db.getAllPlayers()
+      ])
+
+      const { selectedPlayer } = get()
+      let updatedSelected: Player | null = null
+
+      if (selectedPlayer) {
+        updatedSelected = allPlayers.find(player => player.id === selectedPlayer.id) || null
+      }
+
+      set({
         filteredPlayers: players,
-        isLoading: false 
+        allPlayers,
+        selectedPlayer: updatedSelected,
+        isLoading: false
       })
-      
+
     } catch (error) {
-      set({ 
+      set({
         error: `Failed to apply filters: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        isLoading: false 
+        isLoading: false
       })
     }
   },
@@ -269,13 +309,13 @@ export const useNBAStore = create<NBAState>((set, get) => ({
   // Update player in database
   updatePlayer: async (id: number, updates: Partial<Player>) => {
     set({ isLoading: true })
-    
+
     try {
       await window.api.db.updatePlayer(id, updates)
-      
+
       // Refresh the filtered players list
       await get().applyFilters({})
-      
+
       // Update selected player if it's the one being updated
       const { selectedPlayer } = get()
       if (selectedPlayer && selectedPlayer.id === id) {
@@ -284,11 +324,11 @@ export const useNBAStore = create<NBAState>((set, get) => ({
           set({ selectedPlayer: updatedPlayer })
         }
       }
-      
+
     } catch (error) {
-      set({ 
+      set({
         error: `Failed to update player: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        isLoading: false 
+        isLoading: false
       })
     }
   },
@@ -299,21 +339,82 @@ export const useNBAStore = create<NBAState>((set, get) => ({
     
     try {
       await window.api.db.deletePlayer(id)
-      
+
       // Clear selected player if it was deleted
       const { selectedPlayer } = get()
       if (selectedPlayer && selectedPlayer.id === id) {
         set({ selectedPlayer: null })
       }
-      
+
       // Refresh the filtered players list
       await get().applyFilters({})
-      
+
     } catch (error) {
-      set({ 
+      set({
         error: `Failed to delete player: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        isLoading: false 
+        isLoading: false
       })
+    }
+  },
+
+  loadTeams: async () => {
+    set({ teamsLoading: true })
+    try {
+      const teams = await window.api.db.getTeams()
+      set({ teams, teamsLoading: false })
+    } catch (error) {
+      set({
+        error: `Failed to load teams: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        teamsLoading: false
+      })
+    }
+  },
+
+  createTeam: async (team) => {
+    try {
+      await window.api.db.createTeam(team)
+      await get().loadTeams()
+    } catch (error) {
+      set({ error: `Failed to create team: ${error instanceof Error ? error.message : 'Unknown error'}` })
+    }
+  },
+
+  updateTeam: async (id, updates) => {
+    try {
+      await window.api.db.updateTeam(id, updates)
+      await get().loadTeams()
+    } catch (error) {
+      set({ error: `Failed to update team: ${error instanceof Error ? error.message : 'Unknown error'}` })
+    }
+  },
+
+  deleteTeam: async (id) => {
+    try {
+      await window.api.db.deleteTeam(id)
+      await get().applyFilters({})
+      await get().loadTeams()
+    } catch (error) {
+      set({ error: `Failed to delete team: ${error instanceof Error ? error.message : 'Unknown error'}` })
+    }
+  },
+
+  assignPlayerToTeam: async (teamId, playerId) => {
+    try {
+      await window.api.db.assignPlayerToTeam(teamId, playerId)
+      await get().applyFilters({})
+      await get().loadTeams()
+    } catch (error) {
+      set({ error: `Failed to assign player: ${error instanceof Error ? error.message : 'Unknown error'}` })
+    }
+  },
+
+  removePlayerFromTeam: async (playerId) => {
+    try {
+      await window.api.db.removePlayerFromTeam(playerId)
+      await get().applyFilters({})
+      await get().loadTeams()
+    } catch (error) {
+      set({ error: `Failed to remove player: ${error instanceof Error ? error.message : 'Unknown error'}` })
     }
   }
 }))


### PR DESCRIPTION
## Summary
- extend the database schema and IPC layer with team and team-player assignment operations to expose player team metadata
- expand the Zustand store and add a TeamsSection UI to create, edit, delete, and manage team rosters
- surface team information across the app via a new Teams tab, a team column in the player list, and assignment controls in player details

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e095a741448320befe02b7d2266d12